### PR TITLE
Fix script for `curl: (2) no URL specified`

### DIFF
--- a/src/qbittorrent_telegram_notification.sh
+++ b/src/qbittorrent_telegram_notification.sh
@@ -52,8 +52,8 @@ curl -S -X POST \
   -d chat_id="${CHAT_ID}" \
   -d text="${MESSAGE}" \
   -d parse_mode="HTML" \
-# Remove " | tee -a "${BASEDIR}/notificationsLog.txt" to stop generating a debug log
   "${TG_WEBHOOK_URL}" -w "\n" | tee -a "${BASEDIR}/notificationsLog.txt"
+    # Remove above " | tee -a "${BASEDIR}/notificationsLog.txt" to stop generating a debug log
 
 # Prints an info message in the console
 TR_TIME_LOCALTIME=$(date)


### PR DESCRIPTION
Getting this:

```
curl: (2) no URL specified
curl: try 'curl --help' or 'curl --manual' for more information
./qbittorrent_telegram_notification.sh: line 56: https://api.telegram.org/bot1234:VeryBigSecret/sendMessage: No such file or directory
```

Moving the comment seem to fix it